### PR TITLE
Enable Fill-a-Pix cells to cycle between fill and cross states

### DIFF
--- a/fill_a_pix.html
+++ b/fill_a_pix.html
@@ -10,11 +10,27 @@
     .cell {
       width: 32px; height: 32px;
       border: 1px solid #888;
-      line-height: 32px; font-weight: bold;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      font-weight: bold;
+      position: relative;
       user-select: none;
     }
     .filled { background: #333; color: #fff; }
-    .marked { background: #fff; color: #c00; }
+    .marked { background: #fff; color: #333; }
+    .marked::after {
+      content: '\00d7';
+      position: absolute;
+      inset: 0;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      color: #c00;
+      font-size: 24px;
+      opacity: 0.7;
+      pointer-events: none;
+    }
   </style>
 </head>
 <body>
@@ -113,7 +129,7 @@
       } else if (player[r][c] === 1) {
         player[r][c] = 2;
         cell.className = 'cell marked';
-        cell.textContent = '×';
+        cell.textContent = clues[r][c];
       } else {
         player[r][c] = 0;
         cell.className = 'cell';

--- a/fill_a_pix.html
+++ b/fill_a_pix.html
@@ -14,6 +14,7 @@
       user-select: none;
     }
     .filled { background: #333; color: #fff; }
+    .marked { background: #fff; color: #c00; }
   </style>
 </head>
 <body>
@@ -108,7 +109,11 @@
       if (player[r][c] === 0) {
         player[r][c] = 1;
         cell.className = 'cell filled';
-        cell.textContent = '';
+        cell.textContent = clues[r][c];
+      } else if (player[r][c] === 1) {
+        player[r][c] = 2;
+        cell.className = 'cell marked';
+        cell.textContent = '×';
       } else {
         player[r][c] = 0;
         cell.className = 'cell';

--- a/fill_a_pix.html
+++ b/fill_a_pix.html
@@ -19,18 +19,20 @@
     }
     .filled { background: #333; color: #fff; }
     .marked { background: #fff; color: #333; }
+    .marked::before,
     .marked::after {
-      content: '\00d7';
+      content: '';
       position: absolute;
-      inset: 0;
-      display: flex;
-      align-items: center;
-      justify-content: center;
-      color: #c00;
-      font-size: 24px;
-      opacity: 0.7;
+      top: 50%;
+      left: 50%;
+      width: 140%;
+      height: 2px;
+      background: rgba(170, 170, 170, 0.7);
+      transform-origin: center;
       pointer-events: none;
     }
+    .marked::before { transform: translate(-50%, -50%) rotate(45deg); }
+    .marked::after { transform: translate(-50%, -50%) rotate(-45deg); }
   </style>
 </head>
 <body>


### PR DESCRIPTION
## Summary
- keep clue numbers visible when marking fill-a-pix cells as filled
- allow players to cycle each cell between filled, crossed, and default states
- add styling for crossed cells so marked tiles stand out

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cac37355488321a67467fa40129e6d